### PR TITLE
Feature client endpoint

### DIFF
--- a/resources/config.yml
+++ b/resources/config.yml
@@ -20,54 +20,43 @@ clients:
   - name: ночлежка тест
     type: вк
     url: mks.homeless.ru
-    endpoint: app/version
 
   - name: БФ "Ковчег"
     type: вк
     url: mks.ossne.ru
-    endpoint: app/version
 
   - name: БФ "Люблю и благодарю"
     type: вк
     url: mks.libfund.ru
-    endpoint: app/version
 
   - name: Рука помощи43
     type: вк
     url: mks.helpinghand43.ru
-    endpoint: app/version
 
   - name: новое начало
     type: вк
     url: xn--j1adq.xn--80aaem6ahcfbf0h.xn--p1ai
-    endpoint: app/version
 
   - name: АНО Эпоха Водолея
     type: вк
     url: mks.iznanka.info
-    endpoint: app/version
 
   - name: перспективы
     type: яндекс
     url: mks.perspektivy.ru
-    endpoint: app/version
 
   - name: маяк
     type: яндекс
     url: mks.stophomelessness.ru
-    endpoint: app/version
 
   - name: Милосердие и забота
     type: вк
     url: xn--j1adq.xn-----8kcaeogbuecc7am6akyq5a.xn--p1ai
-    endpoint: app/version
 
   - name: ТЫ ДОМА
     type: вк
     url: mks.td-samara.ru
-    endpoint: app/version
 
   - name: Жить вместе
     type: вк
     url: mks.zhitvmeste.ru
-    endpoint: app/version

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -66,3 +66,8 @@ clients:
     type: вк
     url: mks.td-samara.ru
     endpoint: app/version
+
+  - name: Жить вместе
+    type: вк
+    url: mks.zhitvmeste.ru
+    endpoint: app/version

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -1,3 +1,5 @@
+default_version_endpoint: "app/version"
+
 log:
   dir: ""
 

--- a/src/bot/bot.py
+++ b/src/bot/bot.py
@@ -117,7 +117,7 @@ def handler_text(message):
                     text_messages['processing'],
                     reply_markup=telebot.types.ReplyKeyboardRemove()
                 )
-                header, data = check.get_short_status(config["clients"])
+                header, data = check.get_short_status(config["clients"], config["default_version_endpoint"])
                 bot.send_photo(
                     message.from_user.id,
                     photo=tti.convert(header, data)
@@ -133,7 +133,7 @@ def handler_text(message):
                     reply_markup=telebot.types.ReplyKeyboardRemove()
                 )
 
-                header, data = check.get_long_status(config["clients"])
+                header, data = check.get_long_status(config["clients"], config["default_version_endpoint"])
                 bot.send_photo(
                     message.from_user.id,
                     photo=tti.convert(header, data)

--- a/src/mks/check.py
+++ b/src/mks/check.py
@@ -5,7 +5,7 @@ import requests
 import idna
 
 
-def get_short_status(clients):
+def get_short_status(clients, default_version_endpoint):
     header = ['клиент', 'версия', 'статус']
     data = []
 
@@ -21,7 +21,7 @@ def get_short_status(clients):
             logging.error(ex)
             status = "fail"
 
-        endpoint = client['endpoint'] if client.get('endpoint') else "app/version"
+        endpoint = client['endpoint'] if client.get('endpoint') else default_version_endpoint
 
         try:
             response = requests.get(
@@ -42,7 +42,7 @@ def get_short_status(clients):
     return header, data
 
 
-def get_long_status(clients):
+def get_long_status(clients, default_version_endpoint):
     header = ['клиент', 'версия', 'статус', 'TLS', 'облако', 'URL']
     data = []
 
@@ -64,7 +64,7 @@ def get_long_status(clients):
             status = "fail"
             ssl_status = "fail"
 
-        endpoint = client['endpoint'] if client.get('endpoint') else "app/version"
+        endpoint = client['endpoint'] if client.get('endpoint') else default_version_endpoint
 
         try:
             response = requests.get(

--- a/src/mks/check.py
+++ b/src/mks/check.py
@@ -21,9 +21,11 @@ def get_short_status(clients):
             logging.error(ex)
             status = "fail"
 
+        endpoint = client['endpoint'] if client.get('endpoint') else "app/version"
+
         try:
             response = requests.get(
-                url=f"https://{client['url']}/{client['endpoint']}",
+                url=f"https://{client['url']}/{endpoint}",
                 timeout=60,
                 verify=False
             )
@@ -62,9 +64,11 @@ def get_long_status(clients):
             status = "fail"
             ssl_status = "fail"
 
+        endpoint = client['endpoint'] if client.get('endpoint') else "app/version"
+
         try:
             response = requests.get(
-                url=f"https://{client['url']}/{client['endpoint']}",
+                url=f"https://{client['url']}/{endpoint}",
                 timeout=60,
                 verify=False
             )


### PR DESCRIPTION
The default value for the client endpoints has been set as "app/version" in check.py.  At the same time, an alternative client endpoint can be passed within the resources/config.yml file if needed. 
Example: 
```
- name: new organization
  type: вк
  url: mks.neworganization.ru
  endpoint: app/health
```